### PR TITLE
Fix Ruby syntax on scope example

### DIFF
--- a/docs/scopes.md
+++ b/docs/scopes.md
@@ -25,7 +25,7 @@ whatever you pass as a block. Example:
 
 {% highlight ruby %}
 class Model
-  scope :active { where(:active => true }
+  scope(:active) { where(:active => true }
 end
 {% endhighlight %}
 


### PR DESCRIPTION
Just a minor nitpick :smile_cat:

`{}` blocks need parentheses around the other arguments. Maybe a `do end` block, or a `->{}` lambda would fit better in this case?