### PR TITLE
Update with the new name of the pk generator

### DIFF
--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -20,8 +20,8 @@ The following methods are available on the `Model` class:
   passes the documents in bulk to the database to perform efficient writes.
   If the documents primary keys are left unspecified, the database will assign
   default UUIDs and `insert_all` will return the list of generated ids.
-  You may use `NoBrainer::Document::Id.generate` to generate MongoDB style ids
-  to match the format of model instances.
+  You may use `NoBrainer::Document::PrimaryKey::Generator.generate` to generate
+  MongoDB style ids to match the format of model instances.
 * `Model.sync` is a wrapper for [`r.sync()`](http://www.rethinkdb.com/api/ruby/#sync).
 
 The following predicates are available on a model instance:


### PR DESCRIPTION
Docs seem to be outdated for the PK generator, this should make it up-to-date with `master`.